### PR TITLE
swapped position of patient info and status flag

### DIFF
--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -1,27 +1,4 @@
 <div class="row align-center">
-<div id="callout-patient" class="card columns small-8">
-<% if @patient.record_number < 5 %>
-    <div class="callout success">
-        <i class="fa fa-check-circle float-left" aria-hidden="true"></i>
-        <h3> Up To Date</h3>
-        <p>The patient is up to date</p>
-    </div>
-<% elsif @patient.record_number < 10 %>
-    <div class="callout warning">
-        <i class="fa fa-question-circle float-left" aria-hidden="true"></i>
-        <h3>Review Needed</h3>
-        <p>Please have a nurse review the record</p>
-    </div>
-<% else %>
-    <div class="callout alert">
-    <i class="fa fa-exclamation-circle float-left" aria-hidden="true"></i>
-    <h3>Vaccine Due</h3>
-    <p>The patient requires additional vaccines</p>
-    </div>
-<% end %>
-</div>
-</div>
-<div class="row align-center">
 <div class="card columns small-8 patient-info">
     <h3></h3>
     <table>
@@ -42,6 +19,30 @@
             </tr>
         </tbody>
     </table>
+</div>
+</div>
+
+<div class="row align-center">
+<div id="callout-patient" class="card columns small-8">
+<% if @patient.record_number < 5 %>
+    <div class="callout success">
+        <i class="fa fa-check-circle float-left" aria-hidden="true"></i>
+        <h3> Up To Date</h3>
+        <p>The patient is up to date</p>
+    </div>
+<% elsif @patient.record_number < 10 %>
+    <div class="callout warning">
+        <i class="fa fa-question-circle float-left" aria-hidden="true"></i>
+        <h3>Review Needed</h3>
+        <p>Please have a nurse review the record</p>
+    </div>
+<% else %>
+    <div class="callout alert">
+    <i class="fa fa-exclamation-circle float-left" aria-hidden="true"></i>
+    <h3>Vaccine Due</h3>
+    <p>The patient requires additional vaccines</p>
+    </div>
+<% end %>
 </div>
 </div>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,16 @@ ActiveRecord::Schema.define(version: 20160616133049) do
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
+  create_table "dependencies", force: :cascade do |t|
+    t.integer  "requirer_id"
+    t.integer  "requirement_id"
+    t.integer  "required_years",  default: 0
+    t.integer  "required_months", default: 0
+    t.integer  "required_weeks",  default: 0
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+  end
+
   create_table "immunizations", force: :cascade do |t|
     t.string   "vaccine_code",                       null: false
     t.integer  "patient_profile_id"
@@ -64,16 +74,6 @@ ActiveRecord::Schema.define(version: 20160616133049) do
     t.string   "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "vaccine_requirement_details", force: :cascade do |t|
-    t.integer  "requirer_id"
-    t.integer  "requirement_id"
-    t.integer  "required_years",  default: 0
-    t.integer  "required_months", default: 0
-    t.integer  "required_weeks",  default: 0
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
   end
 
   create_table "vaccine_requirements", force: :cascade do |t|


### PR DESCRIPTION
Patient info is now on top of the page, with the status alert under it. I think it makes more sense this way, to group the alert with the record. When I did testing with registration staff, they all read the patient info first anyway.